### PR TITLE
[add] dj tool can export base settings

### DIFF
--- a/base_dj/discs/song_settings.tmpl
+++ b/base_dj/discs/song_settings.tmpl
@@ -1,0 +1,9 @@
+@anthem.log
+def {{ song.name }}(ctx):
+    """ Setup {{ song.model_id.model }} """
+    model = ctx.env['{{ song.model_id.model }}'].with_context({{ song.model_context }})
+    model.create({
+        {% for key, value in song.dj_get_settings_vals().iteritems() %}# {{ value['label'] }}  # noqa
+        '{{ key }}': {{ value['val'] }},
+        {% endfor %}
+    }).execute()

--- a/dj_compilation_stock/data/dj.xml
+++ b/dj_compilation_stock/data/dj.xml
@@ -8,6 +8,15 @@
     <field name="genre_id" ref="dj_stock_genre" />
   </record>
 
+  <record model="dj.song" id="dj_song_stock_config_settings">
+    <field name="compilation_id" ref="dj_stock_fresh"/>
+    <field name="model_id" ref="stock.model_stock_config_settings"/>
+    <field name="song_type">settings</field>
+    <field name="only_config" eval="True" />
+    <!-- onchange to load defaults for song type does not work w/ xmlid creation :( -->
+    <field name="template_path">base_dj:discs/song_settings.tmpl</field>
+  </record>
+
   <record model="dj.song" id="dj_song_stock_location_xmlids">
     <field name="compilation_id" ref="dj_stock_fresh"/>
     <field name="model_id" ref="stock.model_stock_location"/>


### PR DESCRIPTION
Current example result for stock:
```python
@anthem.log
def stock_config_settings(ctx):
    """ Setup stock.config.settings """
    model = ctx.env['stock.config.settings'].with_context({'tracking_disable':1})
    model.create({
        # Landed Costs: No landed costs  # noqa
        'module_stock_landed_costs': False,
        # Inventory Valuation: Periodic inventory valuation (recommended)  # noqa
        'group_stock_inventory_valuation': False,
        # Minimum Stock Rules: Set lead times in calendar days (easy)  # noqa
        'module_stock_calendar': False,
        # Barcode scanner support  # noqa
        'module_stock_barcode': False,
        # Picking Waves: Manage pickings one at a time  # noqa
        'module_stock_picking_wave': False,
        # Temando integration  # noqa
        'module_delivery_temando': False,
        # Packages: Do not manage packaging  # noqa
        'group_stock_tracking_lot': False,
        # Product Variants: No variants on products  # noqa
        'group_product_variant': False,
        # Warning: All the partners can be used in pickings  # noqa
        'group_warning_stock': False,
        # Company  # noqa
        'company_id': ctx.env.ref('base.main_company').id,
        # Lots and Serial Numbers: Do not track individual product items  # noqa
        'group_stock_production_lot': False,
        # Manage several warehouses  # noqa
        'group_stock_multi_warehouses': False,
        # Product Owners: All products in your warehouse belong to your company  # noqa
        'group_stock_tracking_owner': False,
        # Minimum days to trigger a propagation of date change in pushed/pull flows.  # noqa
        'propagation_minimum_delta': 0,
        # USPS integration  # noqa
        'module_delivery_usps': False,
        # Dropshipping: Suppliers always deliver to your warehouse(s)  # noqa
        'module_stock_dropshipping': False,
        # Quality  # noqa
        'module_quality': False,
        # Procurements: Reserve products immediately after the sale order confirmation  # noqa
        'module_procurement_jit': 1,
        # Packaging Methods: Do not manage packaging  # noqa
        'group_stock_packaging': False,
        # Fedex integration  # noqa
        'module_delivery_fedex': False,
        # Decimal precision on weight  # noqa
        'decimal_precision': 0,
        # Units of Measure: Products have only one unit of measure (easier)  # noqa
        'group_uom': False,
        # Warehouses and Locations usage level: Manage only 1 Warehouse, composed by several stock locations  # noqa
        'warehouse_and_location_usage_level': 1,
        # UPS integration  # noqa
        'module_delivery_ups': False,
        # Expiration Dates: Do not use Expiration Date on serial numbers  # noqa
        'module_product_expiry': False,
        # Manage several stock locations  # noqa
        'group_stock_multi_locations': True,
        # Routes: No automatic routing of products  # noqa
        'group_stock_adv_location': False,
        # DHL integration  # noqa
        'module_delivery_dhl': False,
        
    }).execute()
```
@yvaucher I grabbed just a method from `base_settings_exporter` which might be superseded partially by this update. 