### PR TITLE
Fix error on complete_name because ext_id is already a string and not…

### DIFF
--- a/base_dj/models/dj_song.py
+++ b/base_dj/models/dj_song.py
@@ -423,7 +423,7 @@ class Song(models.Model):
             if val and finfo['type'] == 'many2one':
                 record = self.env[finfo['relation']].browse(val)
                 ext_id = record._dj_export_xmlid()
-                val = self.anthem_xmlid_value(ext_id.complete_name)
+                val = self.anthem_xmlid_value(ext_id)
             # knowing which field does what is always difficult
             # if you don't check settings schema definition.
             # Let's add some helpful info.


### PR DESCRIPTION
… a recordset anymore

Fixes : 
```
2017-08-23 10:08:43,200 1 ERROR empty_lux werkzeug: Error on request:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 177, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 165, in execute
    application_iter = app(environ, start_response)
  File "/opt/odoo/src/odoo/service/server.py", line 249, in app
    return self.app(e, s)
  File "/opt/odoo/src/odoo/service/wsgi_server.py", line 186, in application
    return application_unproxied(environ, start_response)
  File "/opt/odoo/src/odoo/service/wsgi_server.py", line 172, in application_unproxied
    result = handler(environ, start_response)
  File "/opt/odoo/src/odoo/http.py", line 1308, in __call__
    return self.dispatch(environ, start_response)
  File "/opt/odoo/src/odoo/http.py", line 1282, in __call__
    return self.app(environ, start_wrapped)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/wsgi.py", line 588, in __call__
    return self.app(environ, start_response)
  File "/opt/odoo/src/odoo/http.py", line 1481, in dispatch
    result = ir_http._dispatch()
  File "/opt/odoo/src/addons/website_sale/models/ir_http.py", line 15, in _dispatch
    return super(IrHttp, cls)._dispatch()
  File "/opt/odoo/src/addons/website/models/ir_http.py", line 218, in _dispatch
    resp = super(Http, cls)._dispatch()
  File "/opt/odoo/src/addons/web_editor/models/ir_http.py", line 21, in _dispatch
    return super(IrHttp, cls)._dispatch()
  File "/opt/odoo/src/addons/utm/models/ir_http.py", line 20, in _dispatch
    response = super(IrHttp, cls)._dispatch()
  File "/opt/odoo/src/odoo/addons/base/ir/ir_http.py", line 199, in _dispatch
    return cls._handle_exception(e)
  File "/opt/odoo/src/addons/website/models/ir_http.py", line 270, in _handle_exception
    return super(Http, cls)._handle_exception(exception)
  File "/opt/odoo/src/odoo/addons/base/ir/ir_http.py", line 169, in _handle_exception
    return request._handle_exception(exception)
  File "/opt/odoo/src/odoo/http.py", line 768, in _handle_exception
    return super(HttpRequest, self)._handle_exception(exception)
  File "/opt/odoo/src/odoo/addons/base/ir/ir_http.py", line 195, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/src/odoo/http.py", line 827, in dispatch
    r = self._call_function(**self.params)
  File "/opt/odoo/src/odoo/http.py", line 333, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/src/odoo/service/model.py", line 101, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/src/odoo/http.py", line 326, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/src/odoo/http.py", line 935, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/src/odoo/http.py", line 506, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/external-src/odoo-prototype/base_dj/controllers/main.py", line 45, in download_compilation
    filename, content = compilation.burn()
  File "/opt/odoo/external-src/odoo-prototype/base_dj/models/dj_compilation.py", line 121, in burn
    files = self.get_all_tracks()
  File "/opt/odoo/external-src/odoo-prototype/base_dj/models/dj_compilation.py", line 93, in get_all_tracks
    files.append(self.burn_disc())
  File "/opt/odoo/external-src/odoo-prototype/base_dj/models/dj_compilation.py", line 104, in burn_disc
    content = self.dj_render_template()
  File "/opt/odoo/external-src/odoo-prototype/base_dj/models/dj_template.py", line 50, in dj_render_template
    return template.render(**template_vars)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/odoo/external-src/odoo-prototype/base_dj/discs/disc.tmpl", line 15, in top-level template code
    {{ song.dj_render_template() }}
  File "/opt/odoo/external-src/odoo-prototype/base_dj/models/dj_template.py", line 50, in dj_render_template
    return template.render(**template_vars)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/odoo/external-src/odoo-prototype/base_dj/discs/song_settings.tmpl", line 6, in top-level template code
    {% for key, value in song.dj_get_settings_vals().iteritems() %}# {{ value['label'] }}  # noqa
  File "/opt/odoo/external-src/odoo-prototype/base_dj/models/dj_song.py", line 426, in dj_get_settings_vals
    val = self.anthem_xmlid_value(ext_id.complete_name)
AttributeError: 'unicode' object has no attribute 'complete_name'
```