### PR TITLE
Fix crash on write({}) with no vals

### DIFF
--- a/base_dj/models/base.py
+++ b/base_dj/models/base.py
@@ -236,6 +236,8 @@ class Base(models.AbstractModel):
     def _dj_handle_special_fields_write(self, vals):
         if not len(self):
             return
+        if not vals:
+            return
         for fname, info in self._dj_special_fields(vals.keys()):
             if vals[fname]:
                 self._dj_handle_file_field_write(fname, info, vals)


### PR DESCRIPTION
On objects with inherits this can happen and if the object has some
binary fields it crashes.
Because providing an empty list to fields_get returns all the fields of
the model.