### PR TITLE
Improvements

### DIFF
--- a/base_dj/__manifest__.py
+++ b/base_dj/__manifest__.py
@@ -25,6 +25,7 @@
         'security/ir.model.access.csv',
         'data/equalizer.xml',
         'data/export_compilation.xml',
+        'wizards/burn_wiz.xml',
         'wizards/burn_selected_wiz.xml',
         'wizards/load_compilation.xml',
         'views/company.xml',

--- a/base_dj/models/dj/dj_compilation.py
+++ b/base_dj/models/dj/dj_compilation.py
@@ -8,11 +8,7 @@ except ImportError:
     _logger = logging.getLogger(__name__)
     _logger.warning('`autopep8` dependency lib is missing.')
 import os
-try:
-    from urllib import urlencode
-except ImportError:
-    # py3
-    from urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from odoo import models, fields, api, exceptions, _
 from ...utils import create_zipfile, make_title, to_str
@@ -86,7 +82,8 @@ class Compilation(models.Model):
             'install': '__setup__',
             'sample': '__sample__',
         }
-        return mapping.get(self.data_mode, '__setup__')
+        mode = self.env.context.get('dj_force_data_mode', self.data_mode)
+        return mapping.get(mode, '__setup__')
 
     @api.multi
     def _inverse_name(self):

--- a/base_dj/models/dj/dj_compilation.py
+++ b/base_dj/models/dj/dj_compilation.py
@@ -144,7 +144,7 @@ class Compilation(models.Model):
             sanity_msg = _('Warning')
             sanity_state = 'warning'
         return sanity_tmpl.render({
-            'comp': self,
+            'compilation': self,
             'core_comps': core_comps,
             'sanity_state': sanity_state,
             'sanity_msg': sanity_msg,
@@ -159,7 +159,7 @@ class Compilation(models.Model):
         if not self.core:
             core_comps = self.core_compilation_ids
         return info_tmpl.render({
-            'comp': self,
+            'compilation': self,
             'core_comps': core_comps,
         })
 

--- a/base_dj/models/dj/dj_compilation.py
+++ b/base_dj/models/dj/dj_compilation.py
@@ -163,6 +163,17 @@ class Compilation(models.Model):
             'core_comps': core_comps,
         })
 
+    @property
+    @api.model
+    def dj_burn_options_flags(self):
+        return (
+            # ctx keys used to control burning
+            'dj_exclude_core',
+            'dj_xmlid_force',
+            'dj_xmlid_skip_create',
+            'dj_force_data_mode',
+        )
+
     @api.multi
     def download_it(self):
         """Download file."""

--- a/base_dj/views/compilation.xml
+++ b/base_dj/views/compilation.xml
@@ -37,26 +37,8 @@
               <footer>
                 <div class="row">
                   <div id="download_compilation" class="col-xs-6">
-                    <button name="download_it" string="Burn and download" type="object" class="btn-primary"/>
-                    <div class="share">
-                      <p>or share download link (right click on it and hit 'Copy link address'):<br />
-                      <field name="download_url" readonly="1" widget="url" /></p>
-                    </div>
-                    <button name="download_it" string="Burn and download - Exclude core"
-                            type="object" class="btn-primary" context="{'dj_exclude_core': True}"
-                            attrs="{'invisible': [('exclude_core', '=', True)]}"
-                            title="Burn only this compilation excluding core ones"
-                            />
-                    <br />
-                    <br />
-                    <!-- A typical use case is: you played w/ xmlid generation configs and you want to get only the final result -->
-                    <button name="download_it" string="Burn and download - Force xmlids"
-                            type="object" class="btn-primary" context="{'dj_xmlid_force': True}"
-                            title="Burn compilation and force xmlid generation not considering existing ones"
-                            />
-                  </div>
-                  <div id="download_config" class="col-xs-6">
-                    <button name="export_current_config" string="Export current configuration" type="object" class="btn-default"/>
+                    <!-- <button name="download_it" string="Burn and download" type="object" class="btn-primary"/> -->
+                    <button name="%(base_dj.act_dj_compilation_burn)d" string="Burn and download" type="action" class="btn-primary"/>
                   </div>
                 </div>
               </footer>

--- a/base_dj/views/compilation.xml
+++ b/base_dj/views/compilation.xml
@@ -17,6 +17,8 @@
                 <field name="genre_id"/>
                 <field name="name"/>
                 <field name="data_mode"/>
+                <field name="core"/>
+                <field name="exclude_core"/>
               </group>
               <separator string="Exportable songs" />
               <field name="song_ids" context="{'model_tech_name_only': 1, 'default_compilation_id': active_id}">
@@ -61,7 +63,6 @@
             </page>
             <page name="core" string="Core compilations">
               <group>
-                <field name="core"/>
                 <field name="core_compilation_ids">
                   <tree>
                     <field name="genre_id"/>
@@ -69,7 +70,6 @@
                     <field name="data_mode"/>
                   </tree>
                 </field>
-                <field name="exclude_core"/>
               </group>
             </page>
             <page name="advanced" string="Advanced">

--- a/base_dj/views/info_templates.xml
+++ b/base_dj/views/info_templates.xml
@@ -33,23 +33,28 @@
     <h2>
       Core compilations info
     </h2>
-    <div class="core" t-if="core_comps">
-      <strong>Core compilations involved and their models</strong>
-      <p class="text-mute" style="font-size:90%">
-        Compilations listed here we'll be included in the export. <br />
-        You can exlude them by default with the specific flag in "Core compilations" tab. <br />
-        You can exclude them on demand on burn by using the specific button below.
-      </p>
-      <ol>
-        <li t-foreach="core_comps" t-as="core">
-          <strong class="comp_name" t-field="core.name" />:
-          <!--list models -->
-          <t t-foreach="core.mapped('song_ids').mapped('model_name')" t-as="model">
-            <span class="comp_model" t-esc="model" /><t t-if="not model_last">, </t>
-          </t>
-        </li>
-      </ol>
-      <p>See "Core compilations" tab for more info.</p>
+    <div class="core">
+      <t t-if="core_comps and not compilation.exclude_core">
+        <strong>Core compilations involved and their models</strong>
+        <p class="text-mute" style="font-size:90%">
+          Compilations listed here we'll be included in the export. <br />
+          You can exlude them by default with the specific flag in "Core compilations" tab. <br />
+          You can exclude them on demand on burn by using the specific button below.
+        </p>
+        <ol>
+          <li t-foreach="core_comps" t-as="core">
+            <strong class="comp_name" t-field="core.name" />:
+            <!--list models -->
+            <t t-foreach="core.mapped('song_ids').mapped('model_name')" t-as="model">
+              <span class="comp_model" t-esc="model" /><t t-if="not model_last">, </t>
+            </t>
+          </li>
+        </ol>
+        <p>See "Core compilations" tab for more info.</p>
+      </t>
+      <t t-if="compilation.exclude_core">
+        <strong>"Exclude core compilations" is on: no core compilation included.</strong>
+      </t>
     </div>
 
   </template>

--- a/base_dj/wizards/__init__.py
+++ b/base_dj/wizards/__init__.py
@@ -1,2 +1,3 @@
+from . import burn_wiz
 from . import burn_selected_wiz
 from . import load_compilation

--- a/base_dj/wizards/burn_wiz.py
+++ b/base_dj/wizards/burn_wiz.py
@@ -1,0 +1,111 @@
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models, fields
+from urllib.parse import urlencode
+
+
+class BurnWiz(models.TransientModel):
+    _name = 'dj.compilation.burn.wiz'
+
+    compilation_id = fields.Many2one(
+        string='Compilation to burn',
+        comodel_name='dj.compilation',
+        required=True,
+        readonly=True,
+        default=lambda self: self.env.context.get('active_id'),
+    )
+    dj_force_data_mode = fields.Selection(
+        string='Burn mode',
+        help='Force data mode only for this burn session. '
+             'When this diverges from compilation data mode '
+             '`Force XIDs` is activated but '
+             'newly generated XIDs will not be stored.',
+        required=True,
+        selection=[
+            ('install', 'Install'),
+            ('sample', 'Sample'),
+        ],
+    )
+    core_compilation_ids = fields.Many2many(
+        string='Core compilations',
+        comodel_name='dj.compilation',
+        help='Force included core compilations for this burn session.',
+        readonly=True,
+    )
+    dj_exclude_core = fields.Boolean(
+        string='Exclude core compilations',
+        help='Force EXCLUDE core compilations for this burn session. '
+             'Only current compilation will be burnt.',
+    )
+    dj_xmlid_force = fields.Boolean(
+        string='Force XIDs',
+        help='Force XIDs (re)generation. '
+             'When this option is on XIDs are re-generated for all records '
+             'that are not module specific (like "base.main_company"). '
+             'Combined with "Skip creation of new XIDs" you can generate '
+             'one-shot XIDs that are not stored in DB. '
+             'You could use this to fix some bad XIDs or '
+             'replace outdated XIDs due to XID policy updates.'
+    )
+    dj_xmlid_skip_create = fields.Boolean(
+        string='Skip creation of new XIDs',
+        help='Do not store newly generated XIDs',
+        default=False,
+    )
+    burn_url = fields.Char(
+        string='Share burn URL',
+        default='',
+        readonly=True,
+    )
+
+    @api.onchange('compilation_id')
+    def _onchange_compilation_id(self):
+        self.update({
+            'dj_force_data_mode': self.compilation_id.data_mode,
+            'core_compilation_ids': self.compilation_id.core_compilation_ids,
+        })
+        self._update_url()
+
+    @api.onchange('dj_force_data_mode')
+    def _onchange_data_mode(self):
+        if self.dj_force_data_mode != self.compilation_id.data_mode:
+            self.update({
+                'dj_xmlid_force': True,
+                'dj_xmlid_skip_create': True,
+            })
+        else:
+            self.update({
+                'dj_xmlid_force': False,
+                'dj_xmlid_skip_create': False,
+            })
+        self._update_url()
+
+    @api.onchange('dj_exclude_core')
+    def _onchange_dj_exclude_core(self):
+        core_comps = self.compilation_id.core_compilation_ids
+        if self.dj_exclude_core:
+            core_comps = False
+        self.update({
+            'core_compilation_ids': core_comps,
+        })
+        self._update_url()
+
+    def _update_url(self):
+        config = {}
+        for fname in self.compilation_id.dj_burn_options_flags:
+            if self[fname]:
+                config[fname] = self[fname]
+        self.burn_url = '/dj/download/compilation/{id}?{config}'.format(
+            id=self.compilation_id.id,
+            config=urlencode(config)
+        )
+
+    @api.multi
+    def action_burn(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_url',
+            'target': 'new',
+            'url': self.burn_url,
+        }

--- a/base_dj/wizards/burn_wiz.xml
+++ b/base_dj/wizards/burn_wiz.xml
@@ -1,0 +1,45 @@
+<odoo>
+
+  <record model="ir.ui.view" id="compilation_burn_wiz_form">
+    <field name="name">dj.compilation.burn.wiz.form</field>
+    <field name="model">dj.compilation.burn.wiz</field>
+    <field name="arch" type="xml">
+      <form string="Burn compilation">
+        <group>
+          <field name="compilation_id"/>
+          <field name="dj_force_data_mode"/>
+          <field name="core_compilation_ids">
+            <tree>
+              <field name="name"/>
+              <field name="genre"/>
+              <field name="data_mode"/>
+            </tree>
+          </field>
+          <field name="dj_exclude_core"/>
+          <field name="dj_xmlid_force"/>
+          <field name="dj_xmlid_skip_create"/>
+        </group>
+        <footer>
+          <label for="burn_url" />
+          <br />
+          <field name="burn_url" widget="url" />
+          <hr />
+          <button name="action_burn" type="object" string="Burn" class="oe_highlight"/>
+          or
+          <button string="Cancel" class="oe_link" special="cancel"/>
+        </footer>
+      </form>
+    </field>
+  </record>
+
+  <act_window
+    id="act_dj_compilation_burn"
+    name="Burn Selected Compilations"
+    res_model="dj.compilation.burn.wiz"
+    src_model="dj.compilation"
+    view_mode="form"
+    target="new"
+    view_id="compilation_burn_wiz_form"
+    />
+
+</odoo>


### PR DESCRIPTION
* Add new burn wizard
    
    We had 2 burning buttons on the compilation
    each of them not clearing showing what the user was ablet to obtain.
    
    Now we have only 2 button that opens a burning wizard.
    
    The wizard allows to customize the single burning action via flags.

* Allow override params for song controller too

* Compilation view: fix compilation summary
    
    Do not display core compilations details if "exclude core" is on.
    Move core flags to first page too.

![screenshot from 2018-07-30 11-53-47](https://user-images.githubusercontent.com/347149/43391133-2818c6c6-93f0-11e8-8102-65a083f9c70d.png)
![screenshot from 2018-07-30 11-53-27](https://user-images.githubusercontent.com/347149/43391134-283bc5c2-93f0-11e8-8d44-1db41f62a733.png)
